### PR TITLE
Maintain worlds.json file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Patch Notes
 
+## Version 1.3.0
+
+* Added functionality to create/update a worlds.json file in the actorAPI folder to allow listing available worlds as part of the external viewer. [#10](https://github.com/ardittristan/VTTExternalActorViewer/pull/10)
+
 ## Version 1.2.0
 
 * Add Call of Cthulhu 7th compatibility.

--- a/customFilepickers/foundryFilePicker.js
+++ b/customFilepickers/foundryFilePicker.js
@@ -14,7 +14,7 @@ export default class SilentFilePicker extends FilePicker {
     fd.set("target", path);
     fd.set("upload", file);
     Object.entries(options).forEach((o) => fd.set(...o));
-    console.log(this.uploadURL);
+    console.log('ActorViewer |', this.uploadURL);
     // Dispatch the request
     const request = await fetch(this.uploadURL, { method: "POST", body: fd });
     if (request.status === 413) {

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
 	"name": "externalactor",
 	"title": "External Actor Viewer",
 	"description": "Makes you able to see characters from unloaded worlds.",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"author": "ardittristan#0001",
 	"esmodules": [
 		"actorviewer.js"

--- a/modules/callofcthulhu.js
+++ b/modules/callofcthulhu.js
@@ -13,6 +13,7 @@ Hooks.on("init", () => {
       });
 
       ActorViewer.createActorsFile(actors);
+      ActorViewer.createWorldsFile();
 
       game.settings.set("externalactor", "systemSite", "https://ardittristan.github.io/VTTCoC7thExternalActorSite/");
 

--- a/modules/dnd5e.js
+++ b/modules/dnd5e.js
@@ -29,6 +29,7 @@ Hooks.on("init", () => {
 
       // create json file
       ActorViewer.createActorsFile(actors);
+      ActorViewer.createWorldsFile();
       // set application button url
       game.settings.set("externalactor", "systemSite", "https://ardittristan.github.io/VTTExternalActorSite/");
 

--- a/modules/pf2e.js
+++ b/modules/pf2e.js
@@ -22,6 +22,7 @@ Hooks.on("init", () => {
       });
 
       ActorViewer.createActorsFile(actors);
+      ActorViewer.createWorldsFile();
 
       game.settings.set("externalactor", "systemSite", "https://ardittristan.github.io/VTTPF2eExternalActorSite/");
 


### PR DESCRIPTION
1. Added functionality to create/update a `worlds.json` file in the `actorAPI` folder to allow listing available worlds as part of the external viewer.
2. Prepended `ActorViewer | ` to all of the console.log messages in line with some of the logging that existed.
